### PR TITLE
Correção da tabela usuarios_table

### DIFF
--- a/database/migrations/2024_11_18_163959_usuarios_table.php
+++ b/database/migrations/2024_11_18_163959_usuarios_table.php
@@ -13,7 +13,6 @@ return new class extends Migration
     {
         Schema::create('usuarios', function (Blueprint $table) {
             $table->id();
-            $table->string('name');
             $table->string('email')->unique();
             $table->string('password');
             $table->integer('user_level');


### PR DESCRIPTION
Removi a linha '$table->string('nome');' porque a coluna nome já existe na tabela 2024_11_18_170823_usuarios_clientes_table. 